### PR TITLE
Freeze remote repos as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,9 @@ docker run --rm \
   hasufell/stack2cabal
 ```
 
-## Limitations
+## Notes
 
 Hackage packages that are specified as git repositories in e.g. `extra-deps` might
 have a different version than the stack resolver. `stack2cabal` will still record the
-version of the stack resolver in `cabal.project.freeze`. In order to fix that remove
-the constraint of such dependencies entirely from the freeze file.
-
-Also see [#1](https://github.com/hasufell/stack2cabal/issues/1).
+version of the stack resolver in `cabal.project.freeze` unless you pass `--freeze-remotes`
+(which takes longer time).

--- a/stack2cabal.cabal
+++ b/stack2cabal.cabal
@@ -31,12 +31,17 @@ common deps
     , directory
     , extra                 >=1.6.13
     , filepath
+    , filepattern           >=0.1.2
     , hpack                 ==0.34.2
     , HsYAML                ^>=0.2
     , http-client           >=0.5.14
     , http-client-tls       >=0.3.5.3
     , optparse-applicative  >=0.15
+    , process               >=1.6.9.0
+    , safe                  >=0.3.19
     , text                  >=1.2.3.1
+    , temporary             >=1.3
+    , unordered-containers  >=0.2.10.0
 
   if flag(ghcflags)
     build-tool-depends: hsinspect:hsinspect -any


### PR DESCRIPTION
This also fixes #1, because if
a remote repo is a hackage dep, it will
replace the version from the statically stack-generated
freeze info now.

@KTorZ