### PR TITLE
build(nix): add aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = { self, nixpkgs, flake-utils, haskellNix }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ] (system:
     let
       overlays = [ haskellNix.overlay
         (final: prev: {


### PR DESCRIPTION
Only needed to add `aarch64-darwin` to the supported platform list. I did a build and it seems to work just fine.

Closes #50